### PR TITLE
Remove deprecated status from SBIE1313

### DIFF
--- a/Content/AllPages.md
+++ b/Content/AllPages.md
@@ -354,7 +354,7 @@
 
 [SBIE1312](SBIE1312.md)
 
-~~[SBIE1313](SBIE1313.md)~~ (deprecated since Sandboxie 0.7.1 / 5.48.5)
+[SBIE1313](SBIE1313.md)
 
 [SBIE1314](SBIE1314.md)
 

--- a/Content/SBIE1313.md
+++ b/Content/SBIE1313.md
@@ -1,7 +1,5 @@
 # SBIE1313
 
-**DEPRECATED**
-
 **Message:** SBIE1313 Blocked direct disk access by process _program.exe_
 
 **Logged To:** [Popup Message Log](PopupMessageLog.md).


### PR DESCRIPTION
Apparently I misinterpreted a comment in the source code... so SBIE1313 is always applied correctly for all processes, but not for SandboxieCrypto.exe process since Sandboxie 0.7.1 / 5.48.5.