### PR TITLE
Replace most of 'deprecated' wordings

### DIFF
--- a/Content/AllPages.md
+++ b/Content/AllPages.md
@@ -20,19 +20,19 @@
 
 ### B
 
-~~[Block Drivers](BlockDrivers.md)~~ (deprecated since Sandboxie v4.xx)
+~~[Block Drivers](BlockDrivers.md)~~ (removed since Sandboxie v4.xx)
 
-~~[Block Fake Input](BlockFakeInput.md)~~ (deprecated since Sandboxie v4.xx)
+~~[Block Fake Input](BlockFakeInput.md)~~ (removed since Sandboxie v4.xx)
 
 [Block Net Param](BlockNetParam.md)
 
-~~[Block Password](BlockPassword.md)~~ (deprecated)
+~~[Block Password](BlockPassword.md)~~ (obsolete)
 
-~~[Block Port](BlockPort.md)~~ (deprecated since Sandboxie v0.9.0 / 5.51.0)
+~~[Block Port](BlockPort.md)~~ (removed since Sandboxie v0.9.0 / 5.51.0 in favour of NetworkAccess)
 
-~~[Block Sys Param](BlockSysParam.md)~~ (deprecated since Sandboxie v4.xx)
+~~[Block Sys Param](BlockSysParam.md)~~ (removed since Sandboxie v4.xx)
 
-~~[Block Win Hooks](BlockWinHooks.md)~~ (deprecated since Sandboxie v4.xx)
+~~[Block Win Hooks](BlockWinHooks.md)~~ (removed since Sandboxie v4.xx)
 
 [Border Color](BorderColor.md)
 
@@ -46,7 +46,7 @@
 
 [Breakout Process](BreakoutProcess.md)
 
-~~[Byte Order Mark](ByteOrderMark.md)~~ (deprecated since Sandboxie v0.6.5 / 5.47.0)
+~~[Byte Order Mark](ByteOrderMark.md)~~ (removed since Sandboxie v0.6.5 / 5.47.0)
 
 ### C
 
@@ -78,7 +78,7 @@
 
 [Delete V2](Delete-V2.md)
 
-[Deprecated Sandboxie Ini Settings](DeprecatedSandboxieIniSettings.md)
+[Deprecated/Obsolete/Removed Sandboxie Ini Settings](DeprecatedSandboxieIniSettings.md)
 
 [Description](Description.md)
 
@@ -238,9 +238,9 @@
 
 [Privacy Mode](PrivacyMode.md)
 
-~~[Process Limit 1](ProcessLimit1.md)~~ (deprecated)
+~~[Process Limit 1](ProcessLimit1.md)~~ (removed since Sandboxie v0.7.1 / 5.48.5 in favour of ProcessLimit)
 
-~~[Process Limit 2](ProcessLimit2.md)~~ (deprecated)
+~~[Process Limit 2](ProcessLimit2.md)~~ (removed since Sandboxie v0.7.1 / 5.48.5 in favour of ProcessLimit)
 
 [Program Name Prefix](ProgramNamePrefix.md)
 
@@ -352,13 +352,13 @@
 
 [SBIE1241](SBIE1241.md)
 
-~~[SBIE1242](SBIE1242.md)~~ (deprecated since Sandboxie 0.9.0 / 5.51.0)
+~~[SBIE1242](SBIE1242.md)~~ (obsolete since Sandboxie 0.9.0 / 5.51.0)
 
 [SBIE1301](SBIE1301.md)
 
-~~[SBIE1303](SBIE1303.md)~~ (deprecated since Sandboxie 5.31.4)
+~~[SBIE1303](SBIE1303.md)~~ (obsolete since Sandboxie 5.31.4)
 
-~~[SBIE1304](SBIE1304.md)~~ (deprecated)
+~~[SBIE1304](SBIE1304.md)~~ (obsolete)
 
 [SBIE1306](SBIE1306.md)
 
@@ -366,11 +366,11 @@
 
 [SBIE1308](SBIE1308.md)
 
-~~[SBIE1309](SBIE1309.md)~~ (deprecated)
+~~[SBIE1309](SBIE1309.md)~~ (obsolete)
 
-~~[SBIE1310](SBIE1310.md)~~ (deprecated since Sandboxie 5.31.4)
+~~[SBIE1310](SBIE1310.md)~~ (obsolete since Sandboxie 5.31.4)
 
-~~[SBIE1311](SBIE1311.md)~~ (deprecated)
+~~[SBIE1311](SBIE1311.md)~~ (obsolete)
 
 [SBIE1312](SBIE1312.md)
 
@@ -412,7 +412,7 @@
 
 [SBIE2192](SBIE2192.md)
 
-~~[SBIE2193](SBIE2193.md)~~ (deprecated since Sandboxie 1.0.14 / 5.55.14)
+~~[SBIE2193](SBIE2193.md)~~ (obsolete since Sandboxie 1.0.14 / 5.55.14)
 
 [SBIE2202](SBIE2202.md)
 

--- a/Content/ApplicationsSettings.md
+++ b/Content/ApplicationsSettings.md
@@ -40,7 +40,7 @@ Two special settings on the Internet Explorer settings page:
 *   Save outside sandbox: History of search strings and invoked commands.<br>
 For detailed information, see [Sandboxie Ini](SandboxieIni.md) setting: [OpenProtectedStorage](OpenProtectedStorage.md).
 
-*   ~~Save outside sandbox: Account information for Hotmail and Messenger.~~ (deprecated since Sandboxie v0.8.0 / 5.50.0).<br>
+*   ~~Save outside sandbox: Account information for Hotmail and Messenger.~~ (no longer available since Sandboxie v0.8.0 / 5.50.0).<br>
 For detailed information, see [Sandboxie Ini](SandboxieIni.md) setting: [OpenCredentials](OpenCredentials.md).
 *   See also [Save Outside Sandbox in Internet Explorer Tips](InternetExplorerTips.md#save-outside-sandbox) for more information and recommendations.
 

--- a/Content/BlockDrivers.md
+++ b/Content/BlockDrivers.md
@@ -1,8 +1,8 @@
 # Block Drivers
 
-**This feature has been deprecated in SBIE version 4.+ and up. It is no longer supported.**
+**This feature was removed in SBIE version 4.+ and up. It is no longer available.**
 
-_BlockDrivers_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specifies whether Sandboxie will allow sandboxed programs to load drivers into the operating system. However, this setting does _not_ govern the _installation_ of new drivers -- see more below.
+_BlockDrivers_ was a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specified whether Sandboxie should allow sandboxed programs to load drivers into the operating system. However, this setting did _not_ govern the _installation_ of new drivers -- see more below.
 
 Usage:
 

--- a/Content/BlockFakeInput.md
+++ b/Content/BlockFakeInput.md
@@ -1,9 +1,9 @@
 # Block Fake Input
 
-**This feature is no longer supported in SBIE v4 and up.**
+**This feature was removed in SBIE version 4 and up. It is no longer available.**
 
 
-_BlockFakeInput_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specifies whether Sandboxie will allow sandboxed programs to manufacture fake keyboard input and send it to windows of applications running outside that sandbox.
+_BlockFakeInput_ was a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specified whether Sandboxie should allow sandboxed programs to manufacture fake keyboard input and send it to windows of applications running outside that sandbox.
 
 Usage:
 

--- a/Content/BlockPassword.md
+++ b/Content/BlockPassword.md
@@ -1,6 +1,6 @@
 # Block Password
 
-**This feature is deprecated.** **If you use Windows 10, we recommend _OpenSamEndpoint_ since version 0.7.0 / 5.48.0: [#938](https://github.com/sandboxie-plus/Sandboxie/issues/938)**
+**This feature is obsolete. If you use Windows 10 or later, we recommend _OpenSamEndpoint_ since version 0.7.0 / 5.48.0: [#938](https://github.com/sandboxie-plus/Sandboxie/issues/938)**
 
 _BlockPassword_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specifies whether Sandboxie will allow sandboxed programs to change the password of user accounts.
 

--- a/Content/BlockPort.md
+++ b/Content/BlockPort.md
@@ -1,8 +1,8 @@
 # Block Port
 
-**This feature is deprecated since v0.9.0 / 5.51.0. If you have custom BlockPort entries in your Sandboxie.ini, they will need to be updated by hand to the new format, for example `BlockPort=137,138,139,445` -> `NetworkAccess=*,Block;Port=137,138,139,445`**
+**This feature was removed since v0.9.0 / 5.51.0. If you have custom BlockPort entries in your [Sandboxie Ini](SandboxieIni.md), they will need to be updated by hand to the new format, so for example `BlockPort=137,138,139,445` becomes `NetworkAccess=*,Block;Port=137,138,139,445` (currently included in the _Templates.ini_ file under the `[Template_BlockPorts]` section).**
 
-_BlockPort_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specifies IP port numbers which will be blocked for outgoing communications.
+_BlockPort_ was a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specified IP port numbers to block for outgoing communications.
 
 Usage:
 

--- a/Content/BlockSysParam.md
+++ b/Content/BlockSysParam.md
@@ -1,9 +1,9 @@
 # Block Sys Param
 
-**BlockSysParam feature is deprecated.**
+**BlockSysParam feature was removed in SBIE version 4.+ and up. It is no longer available.**
 
 
-_BlockSysParam_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specifies whether Sandboxie will allow sandboxed programs to change various system parameters.
+_BlockSysParam_ was a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specified whether Sandboxie should allow sandboxed programs to change various system parameters.
 
 Usage:
 

--- a/Content/BlockWinHooks.md
+++ b/Content/BlockWinHooks.md
@@ -1,8 +1,8 @@
 # Block Win Hooks
 
-**BlockWinHooks feature is deprecated.**
+**BlockWinHooks feature was removed in SBIE version 4.+ and up. It is no longer available.**
 
-_BlockWinHooks_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specifies whether Sandboxie will allow sandboxed programs to install system-global hooks.
+_BlockWinHooks_ was a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It specified whether Sandboxie should allow sandboxed programs to install system-global hooks.
 
 Usage:
 

--- a/Content/BoxRootFolder.md
+++ b/Content/BoxRootFolder.md
@@ -1,6 +1,6 @@
 # Box Root Folder
 
-**This setting is deprecated. Please see [FileRootPath](FileRootPath.md) instead.**
+**This setting is deprecated. Please use [FileRootPath](FileRootPath.md) instead.**
 
 _BoxRootFolder_ is a global setting in [Sandboxie Ini](SandboxieIni.md). It specifies the folder containing all sandboxes. One sub-folder is created within the container folder for each sandbox in active use.
 

--- a/Content/ByteOrderMark.md
+++ b/Content/ByteOrderMark.md
@@ -1,8 +1,8 @@
 # Byte Order Mark
 
-**This feature is deprecated since v0.6.5 / 5.47.0.**
+**This feature was removed since v0.6.5 / 5.47.0.**
 
-_ByteOrderMark_ is a global setting in [Sandboxie Ini](SandboxieIni.md). It is typically specified as ByteOrderMark=y (see [Yes Or No Settings](YesOrNoSettings.md)), and indicates that [Sandboxie Control](SandboxieControl.md) should insert a UTF-16 UNICODE Byte Order Mark (BOM) character at the top of the configuration file.
+_ByteOrderMark_ was a global setting in [Sandboxie Ini](SandboxieIni.md). It was typically specified as ByteOrderMark=y (see [Yes Or No Settings](YesOrNoSettings.md)), and indicated that [Sandboxie Control](SandboxieControl.md) should insert a UTF-16 UNICODE Byte Order Mark (BOM) character at the top of the configuration file.
 
 Usage:
 

--- a/Content/DeprecatedSandboxieIniSettings.md
+++ b/Content/DeprecatedSandboxieIniSettings.md
@@ -1,23 +1,23 @@
-# Deprecated Sandboxie Ini Settings
+# Deprecated/Obsolete/Removed Sandboxie Ini Settings
 
-The following settings are deprecated.
+The following settings are deprecated, obsolete or removed:
 
-[BlockDrivers](BlockDrivers.md)
+[BlockDrivers](BlockDrivers.md) (removed before the open source release)
 
-[BlockFakeInput](BlockFakeInput.md)
+[BlockFakeInput](BlockFakeInput.md) (removed before the open source release)
 
-[BlockPassword](BlockPassword.md)
+[BlockPassword](BlockPassword.md) (obsolete)
 
-[BlockPort](BlockPort.md)
+[BlockPort](BlockPort.md) (removed in favour of NetworkAccess)
 
-[BlockSysParam](BlockSysParam.md)
+[BlockSysParam](BlockSysParam.md) (removed before the open source release)
 
-[BlockWinHooks](BlockWinHooks.md)
+[BlockWinHooks](BlockWinHooks.md) (removed before the open source release)
 
-[BoxRootFolder](BoxRootFolder.md)
+[BoxRootFolder](BoxRootFolder.md) (deprecated)
 
-[ByteOrderMark](ByteOrderMark.md)
+[ByteOrderMark](ByteOrderMark.md) (removed)
 
-[ProcessLimit1](ProcessLimit1.md) 
+[ProcessLimit1](ProcessLimit1.md) (removed in favour of ProcessLimit)
 
-[ProcessLimit2](ProcessLimit1.md)
+[ProcessLimit2](ProcessLimit1.md) (removed in favour of ProcessLimit)

--- a/Content/InternetExplorerTips.md
+++ b/Content/InternetExplorerTips.md
@@ -77,7 +77,7 @@ Internet Explorer perdiocally checks its feeds from a component which is running
 #### Save Outside Sandbox
 
 *   Setting: Save outside sandbox: History of search strings and invoked commands.
-*   ~~Setting: Save outside sandbox: Account information for Hotmail and Messenger.~~ (deprecated since Sandboxie v0.8.0 / 5.50.0)
+*   ~~Setting: Save outside sandbox: Account information for Hotmail and Messenger.~~ (replaced with [OpenCredentials](OpenCredentials.md) since Sandboxie v0.8.0 / 5.50.0)
 
 The first setting allows Internet Explorer running under Sandboxie to store "AutoComplete" information, which is typically used for keeping history: History of search strings, or history of commands typed into an input box.
 

--- a/Content/NotifyDirectDiskAccess.md
+++ b/Content/NotifyDirectDiskAccess.md
@@ -1,6 +1,6 @@
 # Notify Direct Disk Access
 
-_NotifyDirectDiskAccess_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It is typically specified as _NotifyDirectDiskAccess=y_, and indicates that Sandboxie should issue message [SBIE1313](SBIE1313.md) when programs are denied direct access to a hard disk device.
+_NotifyDirectDiskAccess_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It is typically specified as _NotifyDirectDiskAccess=y_.
 
 Usage:
 ```
@@ -11,6 +11,6 @@ Usage:
    NotifyDirectDiskAccess=y
 ```
 
-Note that the default behavior of Sandboxie is to deny all direct access requests, unless explicit direct access is given to the hard disk device through the [OpenFilePath](OpenFilePath.md) or [OpenPipePath](OpenPipePath.md) settings. Normally, a message is not issued when such access is denied. Use the _NotifyDirectDiskAccess_ setting to have Sandboxie issue message [SBIE1313](SBIE1313.md) when access is denied. Note that message [SBIE1313](SBIE1313.md) does not necessarily indicate malicious behavior.
+Note that the default behavior of Sandboxie is to deny all direct access requests, unless explicit direct access is given to the hard disk device through the [OpenFilePath](OpenFilePath.md) or [OpenPipePath](OpenPipePath.md) settings. Normally, a message is not issued when such access is denied.
 
 This setting can not be altered using [Sandboxie Control](SandboxieControl.md) and must be edited in [Sandboxie Ini](SandboxieIni.md).

--- a/Content/OpenCredentials.md
+++ b/Content/OpenCredentials.md
@@ -20,4 +20,4 @@ To manage Windows credentials, start Control Panel > User Accounts, select an ac
 
 **Note:** Sandboxie stores credentials in the sandboxed protected storage. Thus, if the setting _Save outside sandbox: History of search strings and invoked commands_ in [Sandbox Settings > Applications > Web Browser](ApplicationsSettings.md#web-browser) is enabled, credentials will not be stored in the sandbox, regardless of the OpenCredentials setting.
 
-~~Related [Sandboxie Control](SandboxieControl.md) setting: _Save outside sandbox: Account information for Hotmail and Messenger_ in [Sandbox Settings > Applications > Web Browser](ApplicationsSettings.md#web-browser)~~ (deprecated since Sandboxie v0.8.0 / 5.50.0)
+~~Related [Sandboxie Control](SandboxieControl.md) setting: _Save outside sandbox: Account information for Hotmail and Messenger_ in [Sandbox Settings > Applications > Web Browser](ApplicationsSettings.md#web-browser)~~ (no longer available since Sandboxie v0.8.0 / 5.50.0)

--- a/Content/ProcessLimit1.md
+++ b/Content/ProcessLimit1.md
@@ -1,8 +1,8 @@
 # Process Limit 1
 
-**ProcessLimit features are deprecated.**
+**ProcessLimit1 and ProcessLimit2 were removed since Sandboxie v0.7.1 / 5.48.5 in favour of ProcessLimit (introduced in [v0.9.7 / 5.52.1](https://github.com/sandboxie-plus/Sandboxie/releases/tag/0.9.7)).**
 
-_ProcessLimit1_ and _ProcessLimit2_ are sandbox settings in [Sandboxie Ini](SandboxieIni.md). They limit the maximum number of processes that Sandboxie allows in the sandbox at the same time.
+_ProcessLimit1_ and _ProcessLimit2_ were sandbox settings in [Sandboxie Ini](SandboxieIni.md). They limited the maximum number of processes that Sandboxie allowed in the sandbox at the same time.
 ```
    .
    .

--- a/Content/SBIE1242.md
+++ b/Content/SBIE1242.md
@@ -1,6 +1,6 @@
 # SBIE1242
 
-**DEPRECATED SINCE 0.9.0 / 5.51.0**
+**OBSOLETE SINCE 0.9.0 / 5.51.0**
 
 **Message:** SBIE1242 Monitor buffer overflow
 

--- a/Content/SBIE1303.md
+++ b/Content/SBIE1303.md
@@ -1,6 +1,6 @@
 # SBIE1303
 
-**DEPRECATED**
+**OBSOLETE**
 
 **Message:** SBIE1303 Only one sandbox can be active at a time
 

--- a/Content/SBIE1304.md
+++ b/Content/SBIE1304.md
@@ -1,6 +1,6 @@
 # SBIE1304
 
-**DEPRECATED**
+**OBSOLETE**
 
 **Message:** SBIE1304 Blocked simulated keyboard or mouse input by process _program.exe_
 
@@ -8,13 +8,13 @@
 
 **Explanation:**
 
-This warning message appears when a sandboxed program has simulated keyboard or mouse action which would have been received by a window that is running in another sandbox or outside any sandboxes. The keyboard or mouse action is discarded.
+This warning message appeared when a sandboxed program had simulated keyboard or mouse action which would have been received by a window running in another sandbox or outside any sandboxes. As a result, the keyboard or mouse action was discarded.
 
-The point of this protection is to block a scenario where a malicious program, which is running sandboxed, manages to circumvent Sandboxie by communicating with program outside Sandboxie, such as the Windows Explorer. The malicious program could simulate keyboard actions that would instruct Windows Explorer to navigate into the sandbox and launch a malicious program.
+The point of this protection was to block a scenario where a malicious program running in a sandbox managed to circumvent Sandboxie by communicating with programs outside Sandboxie, such as the Windows Explorer. The malicious program could simulate keyboard actions that would instruct Windows Explorer to navigate into the sandbox and launch a malicious program.
 
 **Games and Full Screen Applications:**
 
-Sometimes this message is issued while launching a game or an application. In that case the message is not an indication of malicious activity, and it is safe to hide message SBIE1304, or to disable this protection. To disable this protection, consult the related documentation pages below.
+Sometimes this message was issued while launching a game or an application. In that case the message was not an indication of malicious activity, and it was safe to hide message SBIE1304, or to disable this protection.
 
 Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Hardware Access](RestrictionsSettings.md#hardware-access-has-been-removed-from-sandboxie-v4-and-up)
 

--- a/Content/SBIE1309.md
+++ b/Content/SBIE1309.md
@@ -1,6 +1,6 @@
 # SBIE1309
 
-**DEPRECATED**
+**OBSOLETE**
 
 **Message:** SBIE1311 Blocked request to change desktop wallpaper by process _program.exe_
 

--- a/Content/SBIE1310.md
+++ b/Content/SBIE1310.md
@@ -1,6 +1,6 @@
 # SBIE1310
 
-**DEPRECATED**
+**OBSOLETE**
 
 **Message:** SBIE1310 Extended features are disabled until the license is reactivated
 
@@ -8,11 +8,9 @@
 
 **Explanation:**
 
-Extra features of Sandboxie were only available for registered licenses before Sandboxie became free software with no limitations (since version 5.31.4). This message indicated that the license has expired.
+This message indicated that the license had expired before Sandboxie became a free software in version 5.31.4.
 
 The [FAQ Licensing](https://sandboxie-website-archive.github.io/www.sandboxie.com/FAQ_Licensing.html) page listed those extra features that were available only in the registered versions of Sandboxie.
-
-**IMPORTANT:** In general, this message does **not** mean that you have to pay for Sandboxie again.
 
 ~~To renew your license, invoke the Sandboxie License Manager: Open [Sandboxie Control](SandboxieControl.md). You can find it in your Windows Start menu, under the Sandboxie program group. Then, select the [Help Menu](HelpMenu.md) and invoke the **Register Sandboxie** command.~~
 

--- a/Content/SBIE1311.md
+++ b/Content/SBIE1311.md
@@ -1,6 +1,6 @@
 # SBIE1311
 
-**DEPRECATED**
+**OBSOLETE**
 
 **Message:** SBIE1311 Blocked request to change desktop wallpaper by process _program.exe_
 

--- a/Content/SBIE1313.md
+++ b/Content/SBIE1313.md
@@ -1,6 +1,6 @@
 # SBIE1313
 
-**DEPRECATED**
+**OBSOLETE**
 
 **Message:** SBIE1313 Blocked direct disk access by process _program.exe_
 
@@ -8,4 +8,4 @@
 
 **Explanation:**
 
-This message indicates that a program requested direct access to a hard disk device and Sandboxie denied this access. Note that the default behavior of Sandboxie is to deny all direct access requests without issuing this message. The message is issued only when the [NotifyDirectDiskAccess](NotifyDirectDiskAccess.md) setting is enabled. Please see [NotifyDirectDiskAccess](NotifyDirectDiskAccess.md) for more information.
+This message indicated that a program requested direct access to a hard disk device and Sandboxie denied this access. Note that the default behavior of Sandboxie is to deny all direct access requests without issuing this message. The message was issued only when the [NotifyDirectDiskAccess](NotifyDirectDiskAccess.md) setting was already enabled. Please see [NotifyDirectDiskAccess](NotifyDirectDiskAccess.md) for more information.

--- a/Content/SBIE2193.md
+++ b/Content/SBIE2193.md
@@ -1,6 +1,6 @@
 # SBIE2193
 
-**DEPRECATED SINCE 1.0.14 / 5.55.14**
+**OBSOLETE SINCE 1.0.14 / 5.55.14**
 
 **Message:** SBIE2193 Make sure to delete the sandbox after completing the update process.
 


### PR DESCRIPTION
This pull request adds better separation between deprecated, obsolete and removed Sandboxie settings.
Considering that there are many changes, any review would be appreciated.