### PR TITLE
fix: No longer let markdown eat leading underscores on __ask__ special box name

### DIFF
--- a/Content/StartCommandLine.md
+++ b/Content/StartCommandLine.md
@@ -36,7 +36,7 @@ In all forms, the parameter _/box:SandboxName_ is applicable, and may be specifi
   "C:\Program Files\Sandboxie\Start.exe"  /box:TestBox  run_dialog
 ```
 
-A special form of the /box parameter is _/box:_**_ask_**__ and causes Start.exe to display the sandbox selection dialog box.
+A special form of the /box parameter is _/box:\_\_ask\_\__ and causes Start.exe to display the sandbox selection dialog box.
 
 The parameter _/silent_ can be used to eliminate some pop-up error messages. For example:
 ```


### PR DESCRIPTION
`ask__` doesn't quite cut it:)

There were also asterisk formatting around it but looking at the silent parameter it seems to display the same in html so I left that out.