### PR TITLE
Update SBIE1152.md

### DIFF
--- a/docs/zh-CN/Content/SBIE1152.md
+++ b/docs/zh-CN/Content/SBIE1152.md
@@ -1,6 +1,6 @@
 # SBIE1152
 
-**消息：** SBIE1152 蹦床内存分配失败 _[[ntstatus](NtStatusCodes.md) / yy]_
+**消息：** SBIE1152 Trampoline分配失败 _[[ntstatus](NtStatusCodes.md) / yy]_
 
 **记录位置：** [系统事件日志](SystemEventLog.md) 和 [弹出消息日志](PopupMessageLog.md)。
 


### PR DESCRIPTION
This PR corrects the Chinese (zh-CN) translation for the term "Trampoline" in the SBIE1152 error message.

Before:蹦床` (Literal translation: "bouncing bed")
After:Trampoline`

Reason: "Trampoline" is a technical term in computer science. The literal translation is misleading and confusing for users. 