### PR TITLE
Add UseAutoRecoverIgnoreForQuick documentation (English and Simplified Chinese)

### DIFF
--- a/docs/Content/AllPages.md
+++ b/docs/Content/AllPages.md
@@ -780,6 +780,8 @@
 
 [USB Sandboxing](../PlusContent/USBSandboxing.md)
 
+[Use Auto Recover Ignore For Quick](UseAutoRecoverIgnoreForQuick.md)
+
 [Use File Image](UseFileImage.md)
 
 [Use Non Rude Hwnd Hack](UseNonRudeHwndHack.md)

--- a/docs/Content/UseAutoRecoverIgnoreForQuick.md
+++ b/docs/Content/UseAutoRecoverIgnoreForQuick.md
@@ -1,0 +1,21 @@
+# Use Auto Recover Ignore For Quick
+
+_UseAutoRecoverIgnoreForQuick_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md), available since Sandboxie Plus 1.18.0. It specifies whether the [AutoRecoverIgnore](AutoRecoverIgnore.md) exclusion list is also applied to the [Quick Recovery](QuickRecovery.md) window, hiding matching files from the list of recoverable files.
+
+Usage:
+
+```
+   .
+   .
+   .
+   [DefaultBox]
+   UseAutoRecoverIgnoreForQuick=n
+```
+
+This setting is enabled by default. Set it to _n_ to show all recoverable files in the Quick Recovery window, including files that match [AutoRecoverIgnore](AutoRecoverIgnore.md) patterns.
+
+Note that this only takes effect when the "Show All" checkbox in the Quick Recovery window is not checked.
+
+In SandMan, this corresponds to the "Use the above exclusion list to hide matching files from the Quick Recovery window" checkbox under Sandbox Options > File Recovery > Immediate Recovery.
+
+Related [Sandboxie Ini](SandboxieIni.md) settings: [AutoRecoverIgnore](AutoRecoverIgnore.md), [RecoverFolder](RecoverFolder.md). See also [Quick Recovery](QuickRecovery.md).

--- a/docs/zh-CN/Content/AllPages.md
+++ b/docs/zh-CN/Content/AllPages.md
@@ -712,6 +712,8 @@
 
 [USB 沙箱化](../PlusContent/USBSandboxing.md)
 
+[在快速恢复中应用自动恢复忽略](UseAutoRecoverIgnoreForQuick.md)
+
 [使用文件映像](UseFileImage.md)
 
 [使用隐私模式](UsePrivacyMode.md)

--- a/docs/zh-CN/Content/UseAutoRecoverIgnoreForQuick.md
+++ b/docs/zh-CN/Content/UseAutoRecoverIgnoreForQuick.md
@@ -1,0 +1,21 @@
+# 在快速恢复中应用自动恢复忽略
+
+_UseAutoRecoverIgnoreForQuick_ 是 [Sandboxie Ini](SandboxieIni.md) 配置文件中的一个沙箱设置，自 Sandboxie Plus 1.18.0 起可用。它用于指定是否将 [自动恢复忽略](AutoRecoverIgnore.md) 的排除列表同时应用于 [快速恢复](QuickRecovery.md) 窗口，从而在可恢复文件列表中隐藏匹配的文件。
+
+用法示例：
+
+```ini
+   .
+   .
+   .
+   [DefaultBox]
+   UseAutoRecoverIgnoreForQuick=n
+```
+
+此设置默认为启用状态。设置为 _n_ 时，快速恢复窗口将显示所有可恢复文件，包括匹配 [自动恢复忽略](AutoRecoverIgnore.md) 模式的文件。
+
+请注意，此设置仅在快速恢复窗口中未勾选“显示全部”复选框时生效。
+
+在 SandMan 中，对应的选项为“沙箱选项 > 文件恢复 > 即时恢复”下的“使用上述排除列表在快速恢复窗口中隐藏匹配的文件”复选框。
+
+相关的 [Sandboxie Ini](SandboxieIni.md) 设置项：[自动恢复忽略](AutoRecoverIgnore.md)、[恢复文件夹](RecoverFolder.md)。另请参阅 [快速恢复](QuickRecovery.md)。


### PR DESCRIPTION
Documents the UseAutoRecoverIgnoreForQuick setting introduced in Sandboxie Plus 1.18.0 (#5278), which applies the AutoRecoverIgnore exclusion list to the Quick Recovery window. Includes the Simplified Chinese translation and updates both AllPages.md indexes.


