### PR TITLE
Document wildcard support for RecoverFolder and AutoRecoverIgnore

### DIFF
--- a/docs/Content/AutoRecoverIgnore.md
+++ b/docs/Content/AutoRecoverIgnore.md
@@ -16,4 +16,8 @@ The first example excludes from Immediate Recovery any files ending in _.part_. 
 
 The second and third examples exclude the specified folders from Immediate Recovery.
 
+Since Sandboxie Plus 1.18.0, entries may contain the wildcards `*` (matches any number of characters), `?` (matches a single character), and `**` (matches any number of characters, including path separators). Paths are matched in their NT, DOS, and network-alias forms.
+
+Since Sandboxie Plus 1.18.0, the exclusion list can also be applied to the [Quick Recovery](QuickRecovery.md) window; see [UseAutoRecoverIgnoreForQuick](UseAutoRecoverIgnoreForQuick.md).
+
 Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Recovery > Immediate Recovery](RecoverySettings.md#immediate-recovery)

--- a/docs/Content/RecoverFolder.md
+++ b/docs/Content/RecoverFolder.md
@@ -18,4 +18,6 @@ The third example setting specifies that QuickRecovery from the InstallBox sandb
 
 Note that when [Quick Recovery](QuickRecovery.md) looks in the specified folder, it also looks in any folders within that folder, and any folders within those folders, for as many levels of depth as are needed.
 
+Since Sandboxie Plus 1.18.0, folder paths may contain the wildcards `*` (matches any number of characters), `?` (matches a single character), and `**` (matches any number of characters, including path separators). Paths are matched in their NT, DOS, and network-alias forms.
+
 Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Recovery > Quick Recovery](RecoverySettings.md#quick-recovery)

--- a/docs/zh-CN/Content/AutoRecoverIgnore.md
+++ b/docs/zh-CN/Content/AutoRecoverIgnore.md
@@ -16,4 +16,8 @@ _AutoRecoverIgnore_ 是 [Sandboxie Ini](SandboxieIni.md) 配置文件中的一�
 
 第二和第三个示例将指定的文件夹从即时恢复范围中排除。
 
+自 Sandboxie Plus 1.18.0 起，条目可以包含通配符 `*`（匹配任意数量的字符）、`?`（匹配单个字符）和 `**`（匹配任意数量的字符，包括路径分隔符）。匹配时会同时涵盖路径的 NT、DOS 和网络别名形式。
+
+自 Sandboxie Plus 1.18.0 起，排除列表也可以应用于 [快速恢复](QuickRecovery.md) 窗口；请参阅 [在快速恢复中应用自动恢复忽略](UseAutoRecoverIgnoreForQuick.md)。
+
 相关的 [Sandboxie控制](SandboxieControl.md) 设置：[沙箱设置 > 恢复 > 即时恢复](RecoverySettings.md#immediate-recovery)

--- a/docs/zh-CN/Content/RecoverFolder.md
+++ b/docs/zh-CN/Content/RecoverFolder.md
@@ -18,5 +18,7 @@ _RecoverFolder_ 是 [沙盘配置文件](SandboxieIni.md) 中的一个沙箱设�
 
 请注意，当 [快速恢复](QuickRecovery.md) 检查指定文件夹时，它还会检查该文件夹内的任何子文件夹，以及这些子文件夹内的任何子文件夹，检查的深度层级按需而定。
 
+自 Sandboxie Plus 1.18.0 起，文件夹路径可以包含通配符 `*`（匹配任意数量的字符）、`?`（匹配单个字符）和 `**`（匹配任意数量的字符，包括路径分隔符）。匹配时会同时涵盖路径的 NT、DOS 和网络别名形式。
+
 相关的 [沙盘控制面板](SandboxieControl.md) 设置：[沙箱设置 > 恢复 > 快速恢复](RecoverySettings.md#quick-recovery)
 


### PR DESCRIPTION
Since Sandboxie Plus 1.18.0 (#3761, #5318), RecoverFolder and AutoRecoverIgnore patterns support the wildcards *, ? and **, matching paths in their NT, DOS and network-alias forms. Also cross-references the new UseAutoRecoverIgnoreForQuick setting from AutoRecoverIgnore. English and Simplified Chinese.

> Thank you for your contribution to the Sandboxie-docs repository.
>
> When proposing related changes across multiple files:
> - [x] Group them into a single pull request
