### PR TITLE
docs(en): correct setting descriptions and navigation links

### DIFF
--- a/docs/Content/AllPages.md
+++ b/docs/Content/AllPages.md
@@ -196,6 +196,8 @@
 
 [Force Process](ForceProcess.md)
 
+[Force Protection On Mount](ForceProtectionOnMount.md)
+
 [Forget Password](ForgetPassword.md)
 
 [Frequently Asked Questions](FrequentlyAskedQuestions.md)
@@ -544,7 +546,7 @@
 
 [SBIE1308](SBIE1308.md)
 
-~~[SBIE1309](SBIE1309.md)~~ (obsolete)
+[SBIE1309](SBIE1309.md)
 
 ~~[SBIE1310](SBIE1310.md)~~ (obsolete since Sandboxie 5.31.4)
 

--- a/docs/Content/ApplicationsSettings.md
+++ b/docs/Content/ApplicationsSettings.md
@@ -76,7 +76,7 @@ To do that, open [Sandbox Settings > Applications > Folders](ApplicationsSetting
 
 After completing the email configuration, you may want to test it, to make sure that even when running under Sandboxie, new emails are not lost when you delete the sandbox. To do that, follow the steps outlined in [Test Email Configuration](TestEmailConfiguration.md).
 
-If your email program is not known to Sandboxie, you can use [Sandbox Settings > Resource Access > File Access > Direct Access](ResourceAccessSettings.md#file-access--direct-access) to explicitly add direct access to the folder containing your mailbox data files.
+If your email program is not known to Sandboxie, you can use [Sandbox Settings > Resource Access > File Access > Direct Access](ResourceAccessSettings.md#file-access-direct-access) to explicitly add direct access to the folder containing your mailbox data files.
 
 See also message [SBIE2212](SBIE2212.md), [Email Protection](EmailProtection.md), and [FAQ Email](FAQEmail.md).
 

--- a/docs/Content/BlockDrivers.md
+++ b/docs/Content/BlockDrivers.md
@@ -34,4 +34,4 @@ OpenFilePath=c:\program files\MyNewSoftware\SoftwareDriver.sys
 
 **Note:** Allowing sandboxed programs to install drivers is not recommended.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)

--- a/docs/Content/BlockFakeInput.md
+++ b/docs/Content/BlockFakeInput.md
@@ -25,4 +25,4 @@ Specifying _BlockFakeInput=n_ indicates that a sandboxed program should be allow
 
 To experiment with this setting, you can run a sandboxed instance of _osk.exe_, the Windows on-screen keyboard.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Hardware Access](RestrictionsSettings.md#hardware-access-has-been-removed-from-sandboxie-v4-and-up)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Hardware Access](RestrictionsSettings.md#hardware-access-removed)

--- a/docs/Content/BlockPassword.md
+++ b/docs/Content/BlockPassword.md
@@ -16,4 +16,4 @@ Usage:
 
 Specifying _n_ indicates that a sandboxed program should be permitted to issue requests to change the user account password.
 
-~~Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)~~
+~~Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)~~

--- a/docs/Content/BlockSysParam.md
+++ b/docs/Content/BlockSysParam.md
@@ -21,4 +21,4 @@ For an extensive discussion about the system parameters that can be changed, ple
 
 **Technical Note:** When Sandboxie blocks a request to change a system parameter, this is logged in the [Resource Access Monitor](ResourceAccessMonitor.md) as operation _(SystemParametersInfo:nnnnnnnn)_ where _nnnnnnnn_ is a hexadecimal value corresponding to the _uiAction_ parameter passed to the SystemParametersInfo API.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)

--- a/docs/Content/BlockWinHooks.md
+++ b/docs/Content/BlockWinHooks.md
@@ -22,4 +22,4 @@ In effect, this restricts the effect of global hooks to a specific sandbox, and 
 
 Specifying _BlockWinHooks=n_ disables this protection, and allows a sandboxed application to install global hooks into all running applications, both inside and outside the sandbox.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)

--- a/docs/Content/ClosedFilePath.md
+++ b/docs/Content/ClosedFilePath.md
@@ -34,6 +34,6 @@ The third example (spanning four lines) disables Internet access within a sandbo
 
 **Note:** Unlike the corresponding OpenFilePath setting, the _ClosedFilePath_ settings always applies to sandboxed programs, whether the program executable file resides within the sandbox, or out of it.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Blocked Access](ResourceAccessSettings.md#file-access--blocked-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Blocked Access](ResourceAccessSettings.md#file-access-blocked-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Files > Add File/Folder > Access column > Closed

--- a/docs/Content/ClosedIpcPath.md
+++ b/docs/Content/ClosedIpcPath.md
@@ -20,8 +20,8 @@ The _ClosedIpcPath_ setting is typically useful to block those resources that Sa
 
 This setting accepts wildcards. For more information on the use of wildcards in the _OpenXxxPath_ and _ClosedXxxPath_ settings, see [OpenFilePath](OpenFilePath.md).
 
-**Note:** Unlike the corresponding [OpenIpcPath](OpenIpcPath.md) setting, the _ClosedKeyPath_ settings always applies to sandboxed programs, whether the program executable file resides within the sandbox, or out of it.
+**Note:** Unlike the corresponding [OpenIpcPath](OpenIpcPath.md) setting, the _ClosedIpcPath_ setting always applies to sandboxed programs, whether the program executable file resides within the sandbox or outside it.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > IPC Access > Blocked Access](ResourceAccessSettings.md#ipc-access--blocked-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > IPC Access > Blocked Access](ResourceAccessSettings.md#ipc-access-blocked-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > IPC > Add IPC Path > Access column > Closed

--- a/docs/Content/ClosedKeyPath.md
+++ b/docs/Content/ClosedKeyPath.md
@@ -22,6 +22,6 @@ The value specified for _ClosedKeyPath_ can include wildcards, although for regi
 
 **Note:** Unlike the corresponding [OpenKeyPath](OpenKeyPath.md) setting, the _ClosedKeyPath_ settings are always applied to programs in the sandbox, regardless of whether the program's executable file is inside or outside the sandbox.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > Registry Access > Blocked Access](ResourceAccessSettings.md#registry-access--blocked-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > Registry Access > Blocked Access](ResourceAccessSettings.md#registry-access-blocked-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Registry > Add Reg Key > Access column > Closed

--- a/docs/Content/DetectingKeyLoggers.md
+++ b/docs/Content/DetectingKeyLoggers.md
@@ -30,7 +30,7 @@ Rootkit key-loggers record keystrokes at the lowest software level, typically by
 
 Once installed, this class of key-loggers may provide the best logging facilities, and may be difficult to get rid of. But to be installed in the first place, this key-logger needs the explicit help of the operating system, and so is easily blocked by Sandboxie.
 
-~~If such a key-logger attempts to install, Sandboxie should report an informational message [SBIE2103](SBIE2103.md), unless the [BlockDrivers](BlockDrivers.md) setting (see also [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)) was explicitly used to disable this protection.~~
+~~If such a key-logger attempts to install, Sandboxie should report an informational message [SBIE2103](SBIE2103.md), unless the [BlockDrivers](BlockDrivers.md) setting (see also [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)) was explicitly used to disable this protection.~~
 
 ### Windows Hook Key-Loggers
 
@@ -42,7 +42,7 @@ It is not uncommon for applications to install such hooks as part of normal oper
 
 ~~The approach Sandboxie takes is to honor the hook request partially, by applying the hook only to applications in the same sandbox as the requesting application.~~
 
-~~The [BlockWinHooks](BlockWinHooks.md) setting (see also [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)) may be used to explicitly disable this protection.~~
+~~The [BlockWinHooks](BlockWinHooks.md) setting (see also [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)) may be used to explicitly disable this protection.~~
 
 ### Windows Message Key-Loggers
 

--- a/docs/Content/DisableForceRules.md
+++ b/docs/Content/DisableForceRules.md
@@ -25,7 +25,7 @@ Valid values:
 
 - Other settings that affect whether a box is considered at all include box enablement for the current SID/session — a box not enabled for the current user/session is not considered during force list creation.[^2]
 
-- `DisableForceRules` does not remove the box or alter other non-force behavior; it only prevents the driver from adding that box's force entries to the runtime force lists.
+- `DisableForceRules` does not remove the box or alter other non-force behavior; it only prevents the driver from adding that box's force entries to the runtime force lists.[^3]
 
 ## Examples
 

--- a/docs/Content/ForceFolder.md
+++ b/docs/Content/ForceFolder.md
@@ -17,7 +17,7 @@ The second example specifies that any files/programs started from drive E will b
 
 * Please keep in mind that shortcuts located inside a ForceFolder, that are pointing to a path that is not a ForceFolder, will not start a Sandboxed application. For example: if you place a shortcut inside C:\ForcedFolder and it points to C:\SomeOtherPathThatIsNotForced, then the shortcut will trigger a non-sandboxed application.
 
-Another consideration is that Modern / Store Apps are not supported. If your default application for opening a specific file type is a Windows Modern app (such as the Photos app in Windows 10), the application will not launch at all. For more information, please see the [Known Conflicts](KnownConflicts.md#uwp--modern--microsoft-store-apps) page.
+Another consideration is that Modern / Store Apps are not supported. If your default application for opening a specific file type is a Windows Modern app (such as the Photos app in Windows 10), the application will not launch at all. For more information, please see the [Known Conflicts](KnownConflicts.md#microsoft-store-apps) page.
 
 See also: [ForceProcess](ForceProcess.md). If both a _ForceFolder_ and a _ForceProcess_ are applicable to a program that is starting, the ForceFolder setting takes precedence.
 

--- a/docs/Content/FrequentlyAskedQuestions.md
+++ b/docs/Content/FrequentlyAskedQuestions.md
@@ -56,7 +56,7 @@ You would be quite safe using Sandboxie. It should be noted that, from time to t
 
 This is very rare and is quickly resolved by closing the hole that is the attack vector.
 
-Thus it's a good idea to have more traditional anti-malware software. This is is the subject of the following question.
+Thus it's a good idea to have more traditional anti-malware software. This is the subject of the following question.
 
 **Back to [Table of Contents](#overview)**
 

--- a/docs/Content/FuncSkipHook.md
+++ b/docs/Content/FuncSkipHook.md
@@ -32,7 +32,7 @@ FuncSkipHook=PStoreCreateInstance
 
 ## Behavior
 
-- The helper `SbieDll_FuncSkipHook` queries the configuration for `FuncSkipHook` entries. For each configured entry it performs a prefix comparison between the configured wide-character string and the ASCII function name being hooked. If the configured string is exhausted while matching the function name's initial characters, the function is considered matched and the hook is skipped.
+- The helper `SbieDll_FuncSkipHook` queries the configuration for `FuncSkipHook` entries. For each configured entry it performs a prefix comparison between the configured wide-character string and the ASCII function name being hooked. If the configured string is exhausted while matching the function name's initial characters, the function is considered matched and the hook is skipped.[^1]
 - For efficiency, if no `FuncSkipHook` entries were found during the first query, subsequent calls skip this check altogether.
 
 ## Technical Notes

--- a/docs/Content/GettingStarted.md
+++ b/docs/Content/GettingStarted.md
@@ -6,7 +6,7 @@ Sandboxie runs your applications in an isolated abstraction area called a sandbo
 
 This Getting Started tutorial will show you:
 
-  * How to to use Sandboxie to run your applications
+  * How to use Sandboxie to run your applications
   * How the changes are trapped in the sandbox
   * How to recover important files and documents out of the sandbox
   * How to delete the sandbox

--- a/docs/Content/InjectDll.md
+++ b/docs/Content/InjectDll.md
@@ -1,7 +1,7 @@
 # Inject Dll
 
 
-_InjectDll_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It tells Sandboxie to "inject" some DLL into every program in the sandbox. "Inject" means the DLL is
+_InjectDll_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It tells Sandboxie to "inject" a DLL into every program in the sandbox. "Inject" means the DLL is loaded into the process. For example:
 ```
    .
    .

--- a/docs/Content/InjectDll64.md
+++ b/docs/Content/InjectDll64.md
@@ -1,6 +1,6 @@
 # Inject Dll 64
 
-_InjectDll_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It tells Sandboxie to "inject" some DLL into every program in the sandbox. "Inject" means the DLL is
+_InjectDll64_ is a sandbox setting in [Sandboxie Ini](SandboxieIni.md). It tells Sandboxie to "inject" a DLL into every program in the sandbox. "Inject" means the DLL is loaded into the process. For example:
 ```
    .
    .

--- a/docs/Content/NormalKeyPath.md
+++ b/docs/Content/NormalKeyPath.md
@@ -11,15 +11,7 @@ Example:
    .
    .
    [DefaultBox]
-   NormalIpcPath=*BaseNamedObjects*\__ComCatalogCache__
-   NormalIpcPath=*BaseNamedObjects*\ComPlusCOMRegTable
-   NormalIpcPath=*BaseNamedObjects*\RotHintTable
-   NormalIpcPath=*BaseNamedObjects*\{A3BD3259-3E4F-428a-84C8-F0463A9D3EB5}
-   NormalIpcPath=*BaseNamedObjects*\{A64C7F33-DA35-459b-96CA-63B51FB0CDB9}
-   NormalIpcPath=\RPC Control\actkernel
-   NormalIpcPath=\RPC Control\epmapper
-   NormalIpcPath=\RPC Control\OLE*
-   NormalIpcPath=\RPC Control\LRPC*
+   NormalKeyPath=HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize\*
 ```
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Registry > Add Reg Key > Access column > Normal

--- a/docs/Content/OpenCredentials.md
+++ b/docs/Content/OpenCredentials.md
@@ -16,7 +16,7 @@ Windows credentials are used primarily by Windows and Microsoft applications to 
 *   Network shares
 *   Microsoft accounts
 
-To manage Windows credentials, start Control Panel > User Accounts, select an account, and the click on the Related Task labeled _Manage my network passwords._
+To manage Windows credentials, start Control Panel > User Accounts, select an account, and then click on the Related Task labeled _Manage my network passwords._
 
 **Note:** Sandboxie stores credentials in the sandboxed protected storage. Thus, if the setting _Save outside sandbox: History of search strings and invoked commands_ in [Sandbox Settings > Applications > Web Browser](ApplicationsSettings.md#web-browser) is enabled, credentials will not be stored in the sandbox, regardless of the OpenCredentials setting.
 

--- a/docs/Content/OpenFilePath.md
+++ b/docs/Content/OpenFilePath.md
@@ -32,6 +32,6 @@ The fourth example combines the previous two examples, by showing a path contain
 
 A setting similar to _OpenFilePath_, which is _always_ applied, is [OpenPipePath](OpenPipePath.md).
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Direct Access](ResourceAccessSettings.md#file-access--direct-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Direct Access](ResourceAccessSettings.md#file-access-direct-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Files > Add File/Folder > Access column > Open

--- a/docs/Content/OpenIpcPath.md
+++ b/docs/Content/OpenIpcPath.md
@@ -37,6 +37,6 @@ The third example permits a program running inside the sandbox to have full acce
 
 **Note:** The examples in this page, if applied, will create vulnerabilities within the sandbox. They are meant only to show why some resources are blocked, and how they can be un-blocked and exposed for use, if necessary.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > IPC Access > Direct Access](ResourceAccessSettings.md#ipc-access--direct-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > IPC Access > Direct Access](ResourceAccessSettings.md#ipc-access-direct-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > IPC > Add IPC Path > Access column > Open

--- a/docs/Content/OpenKeyPath.md
+++ b/docs/Content/OpenKeyPath.md
@@ -20,6 +20,6 @@ The value specified for _OpenKeyPath_ can include wildcards, although for regist
 
 **Note:** For security reasons, this setting does not apply when the program executable file resides within the sandbox. This means that (potentially malicious) software downloaded into your computer and executed, cannot take advantage of this setting.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > Registry Access > Direct Access](ResourceAccessSettings.md#registry-access--direct-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > Registry Access > Direct Access](ResourceAccessSettings.md#registry-access-direct-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Registry > Add Reg Key > Access column > Open

--- a/docs/Content/OpenPipePath.md
+++ b/docs/Content/OpenPipePath.md
@@ -24,6 +24,6 @@ Will allow the sandboxed program to manage shares and user accounts on the compu
 
 **Note:** This specific example is not recommended, as it weakens the protection of the sandbox.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Full Access](ResourceAccessSettings.md#file-access--full-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Full Access](ResourceAccessSettings.md#file-access-full-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Files > Add File/Folder > Access column > Open for All

--- a/docs/Content/PlusMigrationGuide.md
+++ b/docs/Content/PlusMigrationGuide.md
@@ -26,7 +26,7 @@ The feature to copy an existing box can be found now on another place. (See the 
 
 ![](../Media/Migration/3.png)
 
-To copy a existing box configuration, the "Duplicate Sandbox" menu command can be used.
+To copy an existing box configuration, the "Duplicate Sandbox" menu command can be used.
 
 ## View Menu
 

--- a/docs/Content/QuickRecovery.md
+++ b/docs/Content/QuickRecovery.md
@@ -12,7 +12,7 @@ The rudimentary approach is to use the regular, non-sandboxed Windows Explorer t
 
 The Quick Recovery feature makes it easier to extract files (and even whole folders) that are created and saved by sandboxed programs. It scans a few sandboxed folders, which have to be selected in advance, and lists the files (and folders) it finds within them. These files (and folders) can be recovered into the corresponding location outside the sandbox, or to any location.
 
-To invoke the Quick Recovery window, use the [Sandbox Menu > Sandbox > Quick Recovery](SandboxMenu.md#sandbox-menu) command (or the corresponding command from the [Tray Icon Menu](TrayIconMenu.md)). Quick Recovery also appear as part of the [Delete Sandbox](DeleteSandbox.md) window.
+To invoke the Quick Recovery window, use the [Sandbox Menu > Sandbox > Quick Recovery](SandboxMenu.md#sandbox-menu) command (or the corresponding command from the [Tray Icon Menu](TrayIconMenu.md)). Quick Recovery also appears as part of the [Delete Sandbox](DeleteSandbox.md) window.
 
 **The Quick Recovery Window**
 

--- a/docs/Content/ReadFilePath.md
+++ b/docs/Content/ReadFilePath.md
@@ -17,6 +17,6 @@ This example forces the C:\WINDOWS folder, and everything below it, to be readab
 
 Note: _ReadFilePath_ is a restricted form of [OpenFilePath](OpenFilePath.md). As with _OpenFilePath_, any already-existing sandboxed contents for the specified file or folder locations, are ignored.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Read-Only Access](ResourceAccessSettings.md#file-access--read-only-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Read-Only Access](ResourceAccessSettings.md#file-access-read-only-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Files > Add File/Folder > Access column > Read Only

--- a/docs/Content/ReadKeyPath.md
+++ b/docs/Content/ReadKeyPath.md
@@ -15,8 +15,8 @@ Example:
 
 This example forces the _Policies_ key, and everything below it, to be readable, but not writable (or deletable) by sandboxed programs.
 
-Note: _ReadKeyPath_ is a restricted form of [OpenKeyPath](OpenKeyPath.md). As with _OpenKeyPath_, any already-existing sandboxed contents for the specified file or folder locations, are ignored.
+Note: _ReadKeyPath_ is a restricted form of [OpenKeyPath](OpenKeyPath.md). As with _OpenKeyPath_, any already-existing sandboxed contents for the specified registry key locations are ignored.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > Registry Access > Read-Only Access](ResourceAccessSettings.md#registry-access--read-only-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > Registry Access > Read-Only Access](ResourceAccessSettings.md#registry-access-read-only-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Registry > Add Reg Key > Access column > Read Only

--- a/docs/Content/SBIE1211.md
+++ b/docs/Content/SBIE1211.md
@@ -1,4 +1,4 @@
-#SBIE1211
+# SBIE1211
 
 **Message:** SBIE1211 Could not initiate sandboxing for process _name_
 

--- a/docs/Content/SBIE1304.md
+++ b/docs/Content/SBIE1304.md
@@ -16,6 +16,6 @@ The point of this protection was to block a scenario where a malicious program r
 
 Sometimes this message was issued while launching a game or an application. In that case the message was not an indication of malicious activity, and it was safe to hide message SBIE1304, or to disable this protection.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Hardware Access](RestrictionsSettings.md#hardware-access-has-been-removed-from-sandboxie-v4-and-up)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Hardware Access](RestrictionsSettings.md#hardware-access-removed)
 
 Related [Sandboxie Ini](SandboxieIni.md) setting: [BlockFakeInput](BlockFakeInput.md).

--- a/docs/Content/SBIE1309.md
+++ b/docs/Content/SBIE1309.md
@@ -1,15 +1,13 @@
 # SBIE1309
 
-**OBSOLETE**
-
-**Message:** SBIE1311 Blocked request to change desktop wallpaper by process _program.exe_
+**Message:** SBIE1309 Denied attempt to change account password
 
 **Logged To:** [Popup Message Log](PopupMessageLog.md).
 
 **Explanation:**
 
-Sandboxie detected that a program issued a request to change the desktop wallpaper, and blocked the request.
+Sandboxie detected that a sandboxed program attempted to change a user account password and denied the request.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)
+~~Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)~~
 
-Related [Sandboxie Ini](SandboxieIni.md) settings: [BlockSysParam](BlockSysParam.md).
+Related [Sandboxie Ini](SandboxieIni.md) setting: [BlockPassword](BlockPassword.md).

--- a/docs/Content/SBIE1311.md
+++ b/docs/Content/SBIE1311.md
@@ -10,6 +10,6 @@
 
 Sandboxie detected that a program issued a request to change the desktop wallpaper, and blocked the request.
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)
 
 Related [Sandboxie Ini](SandboxieIni.md) settings: [BlockSysParam](BlockSysParam.md).

--- a/docs/Content/SBIE1314.md
+++ b/docs/Content/SBIE1314.md
@@ -12,6 +12,6 @@ Note that at this time, the message is not actually issued when a program attemp
 
 To permit a program to alter network and firewall parameters, please see the following settings:
 
-~~Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Hardware Access](RestrictionsSettings.md#hardware-access--removed)~~
+~~Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Hardware Access](RestrictionsSettings.md#hardware-access-removed)~~
 
 Related [Sandboxie Ini](SandboxieIni.md) settings: [BlockNetParam](BlockNetParam.md).

--- a/docs/Content/SBIE1408.md
+++ b/docs/Content/SBIE1408.md
@@ -6,6 +6,6 @@
 
 **Explanation:**
 
-Sandboxie needs to translate security S-1-5-x-y-z to a user account name. This message indicates that an error has occurred and revented this translation.
+Sandboxie needs to translate security S-1-5-x-y-z to a user account name. This message indicates that an error has occurred and prevented this translation.
 
 If this message is not accompanied by message [SBIE2209](SBIE2209.md), then it may be an indication that the Sandboxie service is not running.

--- a/docs/Content/SBIE2103.md
+++ b/docs/Content/SBIE2103.md
@@ -15,6 +15,6 @@ This message indicates that a sandboxed program has requested to start a driver,
 
 Note, depending on the circumstances, this message _may_ indicate that an attempt to install a malicious [rootkit](https://en.wikipedia.org/wiki/Rootkit) into the system, has been subverted by Sandboxie. On the other hand, if this message appears during the sandboxed installation of a program that is known to install and activate drivers, then the previous statement does not apply.
 
-~~Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access--removed)~~
+~~Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Restrictions > Low-Level Access](RestrictionsSettings.md#low-level-access-removed)~~
 
 ~~Related [Sandboxie Ini](SandboxieIni.md) setting: [BlockDrivers](BlockDrivers.md)~~

--- a/docs/Content/SBIE2308.md
+++ b/docs/Content/SBIE2308.md
@@ -6,9 +6,9 @@
 
 **Explanation:**
 
-Inter-process communication (IPC) objects are logical objects which are used for various forms of communication between programs. The IPC objects have identifying names and are organized into a hierarchial structure of directories.
+Inter-process communication (IPC) objects are logical objects which are used for various forms of communication between programs. The IPC objects have identifying names and are organized into a hierarchical structure of directories.
 
-Sandboxie redirects all IPC objects created by sandboxed programs to an isolated directory in the hierarchial structure, in order to guarantee separation of communications between programs inside and outside the sandbox.
+Sandboxie redirects all IPC objects created by sandboxed programs to an isolated directory in the hierarchical structure, in order to guarantee separation of communications between programs inside and outside the sandbox.
 
 This message indicates that Sandboxie failed to create the isolated directory.
 

--- a/docs/Content/SBIE2313.md
+++ b/docs/Content/SBIE2313.md
@@ -10,7 +10,7 @@ Sandboxie was not able to execute one of its own programs. Check access permissi
 
 **Possible Causes**
 
-*   Sandboxie was configured to block access to the folder containing its program files. See [Sandbox Settings > Resource Access > File Access > Blocked Access](ResourceAccessSettings.md#file-access--blocked-access).
+*   Sandboxie was configured to block access to the folder containing its program files. See [Sandbox Settings > Resource Access > File Access > Blocked Access](ResourceAccessSettings.md#file-access-blocked-access).
 
 *   A third-party (HIPS) security software was configured to block the execution of the program mentioned in the message.
 

--- a/docs/Content/SBIE2314.md
+++ b/docs/Content/SBIE2314.md
@@ -22,6 +22,6 @@ This message indicates that a program that was launched in this way to receive t
 
 As of version 3.32 this message can only be issued for the Internet Explorer program, _iexplore.exe_, and only when Internet Explorer has been configured as a [forced program](ProgramStartSettings.md#forced-programs).
 
-The message indicates that a special instance of a Internet Explorer, which has been started in order to accept an Internet address (a URL) from a program running outside the sandbox, has encountered an error.
+The message indicates that a special instance of Internet Explorer, which has been started in order to accept an Internet address (a URL) from a program running outside the sandbox, has encountered an error.
 
 You should be able to work around this problem by invoking the [Disable Forced Programs](FileMenu.md#disable-forced-programs) command and retrying the operation that opens an Internet address.

--- a/docs/Content/SBIEMessages.md
+++ b/docs/Content/SBIEMessages.md
@@ -52,7 +52,7 @@ Some messages display details which include NT status codes, denoted in the help
 [SBIE1306](SBIE1306.md)
 [SBIE1307](SBIE1307.md)
 [SBIE1308](SBIE1308.md)
-~~[SBIE1309](SBIE1309.md)~~
+[SBIE1309](SBIE1309.md)
 ~~[SBIE1310](SBIE1310.md)~~
 ~~[SBIE1311](SBIE1311.md)~~
 [SBIE1312](SBIE1312.md)

--- a/docs/Content/SandboxMenu.md
+++ b/docs/Content/SandboxMenu.md
@@ -23,7 +23,7 @@ One or more sub-menus appear for each sandbox defined. The default configuration
 *   The _Explore Contents_ command opens an _unsandboxed_ folder view for the contents of the sandbox _outside the supervision of Sandboxie_. If possible, use the [Files And Folders View](FilesAndFoldersView.md) to browse the contents of the sandbox.
 *   The _Sandbox Settings_ command opens the [Sandbox Settings](SandboxSettings.md) window.
 *   The _Rename Sandbox_ command changes the name of the sandbox.
-*   The _Remove Sandbox_ command removes a sandboxed created using the [Create New Sandbox](SandboxMenu.md#create-new-sandbox) command.
+*   The _Remove Sandbox_ command removes a sandbox created using the [Create New Sandbox](SandboxMenu.md#create-new-sandbox) command.
 
 These commands, except for Rename Sandbox and Remove Sandbox, are also available in the [Tray Icon Menu](TrayIconMenu.md).
 

--- a/docs/Content/SandboxieIni.md
+++ b/docs/Content/SandboxieIni.md
@@ -13,7 +13,7 @@ Sandboxie looks for the file Sandboxie.ini in the following folders, in this ord
 
 The search for Sandboxie.ini ends when an instance of the file is found, and all other instances are ignored.
 
-When [Sandboxie Control](SandboxieControl.md) updates the configuration, it rewrites the file Sandboxie.ini file in the folder from which the configuration was last read. Thus, if the file is manually moved, Sandboxie configuration must be manually [reloaded](ConfigureMenu.md#reload-configuration). (Restarting the computer would have the same effect.)
+When [Sandboxie Control](SandboxieControl.md) updates the configuration, it rewrites the Sandboxie.ini file in the folder from which the configuration was last read. Thus, if the file is manually moved, Sandboxie configuration must be manually [reloaded](ConfigureMenu.md#reload-configuration). (Restarting the computer would have the same effect.)
 
 **Note:** Sandboxie does not support any other custom location for the Sandboxie.ini file.
 

--- a/docs/Content/SandboxieTrace.md
+++ b/docs/Content/SandboxieTrace.md
@@ -110,7 +110,7 @@ When **GuiTrace** is enabled, the trace also produces entries like the following
 ```
 These entries have a few formats. The first word after (GA) or (GD) identifies the type of the entry.
 
-When the first word is _WinHook_ or _AccHook_, the entry indicates installation of a hook. Its installation is permitted for (GA) entries, and denied for (GD) entries. _WinHook_ is a standard Windows hook, followed by the type of the hook (see [SetWidowsHookEx in MSDN](https://www.google.com/search?hl=en&q=setwindowshookex+msdn)). _AccHook_ is an accessibility hook (see [SetWinEventHook in MSDN](https://www.google.com/search?hl=en&q=setwineventhook+msdn)).
+When the first word is _WinHook_ or _AccHook_, the entry indicates installation of a hook. Its installation is permitted for (GA) entries, and denied for (GD) entries. _WinHook_ is a standard Windows hook, followed by the type of the hook (see [SetWindowsHookEx in MSDN](https://www.google.com/search?hl=en&q=setwindowshookex+msdn)). _AccHook_ is an accessibility hook (see [SetWinEventHook in MSDN](https://www.google.com/search?hl=en&q=setwineventhook+msdn)).
 
 Both entries identify the thread number (tid) process number (pid) into which the hook was to be installed.
 

--- a/docs/Content/SecureDeleteSandbox.md
+++ b/docs/Content/SecureDeleteSandbox.md
@@ -1,6 +1,6 @@
 # Secure Delete Sandbox
 
-Typical file deletion makes data inaccessible to the operating system and programs, but the data is not physically wiped from the hard drive storage medium, and may be recovered by by a data recovery technician. To make this recovery more difficult, third-party software exists that can perform a _secure deletion._ This is typically accomplished by overwriting the data multiple times before deleting it.
+Typical file deletion makes data inaccessible to the operating system and programs, but the data is not physically wiped from the hard drive storage medium, and may be recovered by a data recovery technician. To make this recovery more difficult, third-party software exists that can perform a _secure deletion._ This is typically accomplished by overwriting the data multiple times before deleting it.
 
 For more information, see [Data remanence in Wikipedia](https://en.wikipedia.org/wiki/Data_remanence).
 

--- a/docs/Content/UseNonRudeHwndHack.md
+++ b/docs/Content/UseNonRudeHwndHack.md
@@ -42,7 +42,7 @@ The logic is: `!Dll_CompartmentMode`[^5] - meaning it's enabled unless compartme
 
 ## Related Issues
 
-This setting was introduced to address fullscreen compatibility issues, particularly referenced as GitHub issue [#4761](https://github.com/sandboxie-plus/Sandboxie/issues/4761)[^6].
+This setting was introduced to address fullscreen compatibility issues, particularly referenced as GitHub issue [#4761](https://github.com/sandboxie-plus/Sandboxie/issues/4761).
 
 [^1]: **Source**: guiprop.c: `static BOOLEAN Gui_NonRudeHWND_Hack = FALSE;`
 

--- a/docs/Content/WriteFilePath.md
+++ b/docs/Content/WriteFilePath.md
@@ -19,6 +19,6 @@ This setting is not applicable to files. If the path specified in the setting ma
 
 Note: WriteFilePath is implemented internally as an enhanced form of [ClosedFilePath](ClosedFilePath.md).
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Write-Only Access](ResourceAccessSettings.md#file-access--write-only-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > File Access > Write-Only Access](ResourceAccessSettings.md#file-access-write-only-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Files > Add File/Folder > Access column > Box Only (Write Only)

--- a/docs/Content/WriteKeyPath.md
+++ b/docs/Content/WriteKeyPath.md
@@ -18,6 +18,6 @@ This example hides any data which exists outside the sandbox within the _TypedPa
 
 Note: _WriteKeyPath_ is implemented internally as an enhanced form of [ClosedKeyPath](ClosedKeyPath.md).
 
-Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > Registry Access > Write-Only Access](ResourceAccessSettings.md#registry-access--write-only-access)
+Related [Sandboxie Control](SandboxieControl.md) setting: [Sandbox Settings > Resource Access > Registry Access > Write-Only Access](ResourceAccessSettings.md#registry-access-write-only-access)
 
 Related Sandboxie Plus setting: Sandbox Options > Resource Access > Registry > Add Reg Key > Access column > Box Only (Write Only)


### PR DESCRIPTION
Replaces the IPC examples on the `NormalKeyPath` page with a registry example and corrects the `SBIE1309` message page. The DLL injection explanations are completed too.

Most of the other changes repair section links and missing entries in the page indexes, with a few typo and footnote fixes.
