### PR TITLE
ci(zh-CN): flag deprecated terms in documentation PRs

### DIFF
--- a/.github/workflows/zh-terms.yml
+++ b/.github/workflows/zh-terms.yml
@@ -1,0 +1,25 @@
+name: Check Simplified Chinese terminology
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  terminology:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+      - name: Test the terminology checker
+        run: python -m unittest discover -s tools -p 'test_check_zh_terms.py'
+      - name: Check added Simplified Chinese lines
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python tools/check_zh_terms.py --base "$BASE_SHA" --head "$HEAD_SHA" --github-actions

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ After Sandboxie became [open source](https://news.sophos.com/en-us/2020/04/09/sa
 If you have development, testing or translation skills, then feel free to check out our [Contribution guidelines](https://github.com/sandboxie-plus/Sandboxie/blob/master/CONTRIBUTING.md).
 
 All documentation translators are encouraged to look at the [Multilingual Translation Contribution Guide](https://github.com/sandboxie-plus/sandboxie-docs/issues/175#issuecomment-2840258519) before sending a translation.
+
+Simplified Chinese translations use **沙盒** for Sandboxie containers. Pull requests are checked for deprecated terms in added lines; see the [terminology checker](tools/README.md) for details and local usage.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,32 @@
+# Simplified Chinese terminology check
+
+Use **沙盒** for Sandboxie containers in Simplified Chinese. The community
+[poll](https://github.com/sandboxie-plus/Sandboxie/discussions/5546) and
+[terminology update](https://github.com/sandboxie-plus/Sandboxie/pull/5582)
+established this convention; [documentation issue #250](https://github.com/sandboxie-plus/sandboxie-docs/issues/250)
+tracks its adoption here.
+
+The pull request check flags `沙箱` and `沙盘` in added lines of
+`docs/zh-CN/**/*.md` (including `docs/zh-CN/README.md`) and the root
+`README_zh-CN.md`. It matches the complete terms, so words such as `磁盘` and
+`工具箱` are allowed. Other languages are outside its scope.
+
+The comparison uses the merge base of the base and head commits. Existing
+lines are left alone until edited; changing even one character checks the
+whole new line. Deleted lines are ignored. Renames are treated as a deletion
+and an addition, so the contents of a file moved into a checked path are checked.
+The rule also applies to code blocks and quotations on changed lines.
+Review each reported use in context: containers are `沙盒`, while product
+names such as `Sandboxie` remain untranslated. The checker does not edit files.
+
+Run locally with Python 3.10 or later and Git; no Python packages are needed:
+
+```sh
+python tools/check_zh_terms.py --base origin/main
+python -m unittest discover -s tools -p 'test_check_zh_terms.py'
+```
+
+Only committed changes are checked. Use `--head <commit>` to check a different
+commit, and ensure both revisions and their common history are available locally.
+Exit codes are 0 for success, 1 for deprecated terms and 2 for a check that could
+not be completed. CI uses `--github-actions` to report the affected files and lines.

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,6 +11,13 @@ The pull request check flags `沙箱` and `沙盘` in added lines of
 `README_zh-CN.md`. It matches the complete terms, so words such as `磁盘` and
 `工具箱` are allowed. Other languages are outside its scope.
 
+The phrases `沙盘管理器`, `沙盒管理器` and `沙箱管理器` produce warnings for
+manual review. Use `SandMan` for the Plus UI and `Sandboxie Control` for the
+Classic UI; exact quotations of translated UI labels may be kept. These warnings
+do not fail the check. A manager phrase receives one warning, without a second
+error for the `沙盘` or `沙箱` within it. Separate uses of those deprecated terms
+on the same line still produce errors.
+
 The comparison uses the merge base of the base and head commits. Existing
 lines are left alone until edited; changing even one character checks the
 whole new line. Deleted lines are ignored. Renames are treated as a deletion
@@ -28,5 +35,6 @@ python -m unittest discover -s tools -p 'test_check_zh_terms.py'
 
 Only committed changes are checked. Use `--head <commit>` to check a different
 commit, and ensure both revisions and their common history are available locally.
-Exit codes are 0 for success, 1 for deprecated terms and 2 for a check that could
-not be completed. CI uses `--github-actions` to report the affected files and lines.
+Exit codes are 0 for success (including warnings only), 1 for deprecated term
+errors and 2 for a check that could not be completed. CI uses `--github-actions`
+to report the affected files and lines.

--- a/tools/check_zh_terms.py
+++ b/tools/check_zh_terms.py
@@ -9,7 +9,8 @@ import subprocess
 import sys
 
 
-TERMS = re.compile("沙箱|沙盘")
+# Match manager names first so their shorter 'sandbox' terms are not reported twice.
+TERMS = re.compile("沙[盘盒箱]管理器|沙箱|沙盘")
 HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
 
@@ -18,6 +19,19 @@ class Violation:
     path: str
     line: int
     term: str
+
+    @property
+    def severity(self) -> str:
+        return "warning" if self.term.endswith("管理器") else "error"
+
+    @property
+    def message(self) -> str:
+        if self.severity == "warning":
+            return (
+                f"Check '{self.term}' in context: use 'SandMan' for the Sandboxie Plus UI "
+                "or 'Sandboxie Control' for the Classic UI. Exact UI label quotations may be kept."
+            )
+        return f"Use '沙盒' instead of '{self.term}' in Simplified Chinese documentation."
 
 
 def git(repo: Path, *args: str) -> str:
@@ -93,10 +107,10 @@ def escape_command(value: str, *, property_value: bool = False) -> str:
     return value
 
 
-def github_error(violation: Violation) -> str:
+def github_annotation(violation: Violation) -> str:
     path = escape_command(violation.path, property_value=True)
-    message = escape_command(f"Use '沙盒' instead of '{violation.term}' in Simplified Chinese documentation.")
-    return f"::error file={path},line={violation.line}::{message}"
+    message = escape_command(violation.message)
+    return f"::{violation.severity} file={path},line={violation.line}::{message}"
 
 
 def main() -> int:
@@ -118,13 +132,15 @@ def main() -> int:
 
     for violation in violations:
         if args.github_actions:
-            print(github_error(violation))
+            print(github_annotation(violation))
         else:
-            print(f"{violation.path}:{violation.line}: use '沙盒' instead of '{violation.term}'")
+            print(f"{violation.path}:{violation.line}: {violation.severity}: {violation.message}")
     if violations:
-        print(f"Found {len(violations)} deprecated term(s) in added Simplified Chinese lines.")
-        return 1
-    print("No deprecated terms in added Simplified Chinese lines.")
+        errors = sum(violation.severity == "error" for violation in violations)
+        warnings = len(violations) - errors
+        print(f"Found {errors} error(s) and {warnings} warning(s) in added Simplified Chinese lines.")
+        return 1 if errors else 0
+    print("No terminology issues in added Simplified Chinese lines.")
     return 0
 
 

--- a/tools/check_zh_terms.py
+++ b/tools/check_zh_terms.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Check added Simplified Chinese documentation lines for deprecated terms."""
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+TERMS = re.compile("沙箱|沙盘")
+HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    line: int
+    term: str
+
+
+def git(repo: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "--literal-pathspecs", *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        return result.stdout.decode("utf-8")
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError(error.stderr.decode("utf-8", errors="replace").strip()) from error
+    except (OSError, UnicodeDecodeError) as error:
+        raise RuntimeError(str(error)) from error
+
+
+def is_target(path: str) -> bool:
+    return path == "README_zh-CN.md" or (
+        path.startswith("docs/zh-CN/") and path.endswith(".md")
+    )
+
+
+def added_terms(path: str, patch: str) -> list[Violation]:
+    violations = []
+    new_line = 0
+    remaining = 0
+    for line in patch.split("\n"):
+        match = HUNK.match(line)
+        if match:
+            new_line = int(match[1])
+            remaining = int(match[2]) if match[2] is not None else 1
+        elif remaining and line.startswith("+"):
+            # Inside a hunk, even a line starting with '+++' is document text.
+            for term in sorted(set(TERMS.findall(line[1:]))):
+                violations.append(Violation(path, new_line, term))
+            new_line += 1
+            remaining -= 1
+        elif remaining and line.startswith(" "):
+            new_line += 1
+            remaining -= 1
+    return violations
+
+
+def check(repo: Path, base: str, head: str = "HEAD") -> list[Violation]:
+    base_sha = git(repo, "rev-parse", "--verify", "--end-of-options", f"{base}^{{commit}}").strip()
+    head_sha = git(repo, "rev-parse", "--verify", "--end-of-options", f"{head}^{{commit}}").strip()
+    start = git(repo, "merge-base", base_sha, head_sha).strip()
+    diff_options = ["--no-ext-diff", "--no-textconv", "--no-renames"]
+    # NUL delimiters preserve spaces, Unicode and other special path characters.
+    names = git(
+        repo, "diff", *diff_options, "--name-only", "-z", "--diff-filter=d",
+        start, head_sha, "--",
+    )
+    violations = []
+    for path in names.split("\0"):
+        if not is_target(path):
+            continue
+        patch = git(
+            repo, "diff", *diff_options, "--no-color", "--text", "--unified=0",
+            "--output-indicator-new=+", "--output-indicator-old=-",
+            "--output-indicator-context= ",
+            start, head_sha, "--", path,
+        )
+        violations.extend(added_terms(path, patch))
+    return violations
+
+
+def escape_command(value: str, *, property_value: bool = False) -> str:
+    value = value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if property_value:
+        value = value.replace(":", "%3A").replace(",", "%2C")
+    return value
+
+
+def github_error(violation: Violation) -> str:
+    path = escape_command(violation.path, property_value=True)
+    message = escape_command(f"Use '沙盒' instead of '{violation.term}' in Simplified Chinese documentation.")
+    return f"::error file={path},line={violation.line}::{message}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="Base branch or commit; comparison starts at the merge base")
+    parser.add_argument("--head", default="HEAD", help="PR head branch or commit (default: HEAD)")
+    parser.add_argument("--github-actions", action="store_true", help="Emit file and line annotations")
+    args = parser.parse_args()
+    repo = Path(__file__).resolve().parent.parent
+    try:
+        violations = check(repo, args.base, args.head)
+    except RuntimeError as error:
+        message = f"Unable to check Simplified Chinese terms: {error}"
+        if args.github_actions:
+            print(f"::error::{escape_command(message)}")
+        else:
+            print(message, file=sys.stderr)
+        return 2
+
+    for violation in violations:
+        if args.github_actions:
+            print(github_error(violation))
+        else:
+            print(f"{violation.path}:{violation.line}: use '沙盒' instead of '{violation.term}'")
+    if violations:
+        print(f"Found {len(violations)} deprecated term(s) in added Simplified Chinese lines.")
+        return 1
+    print("No deprecated terms in added Simplified Chinese lines.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_zh_terms.py
+++ b/tools/test_check_zh_terms.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from check_zh_terms import Violation, check, github_error, is_target
+from check_zh_terms import Violation, check, github_annotation, is_target
 
 
 class TermCheckTests(unittest.TestCase):
@@ -65,12 +65,47 @@ class TermCheckTests(unittest.TestCase):
         path = "docs/zh-CN/Content/中文 [one] file.md"
         self.write(path, "沙盒、磁盘和工具箱\n沙箱中的沙箱\n沙盘中的沙盒\n")
         self.write("docs/zh-CN/Content/中文 o file.md", "沙盒\n")
-        self.write("docs/Content/English.md", "沙箱\n")
-        self.write("docs/zh-TW/Example.md", "沙箱\n")
+        self.write("docs/Content/English.md", "沙箱\n沙盒管理器\n")
+        self.write("docs/zh-TW/Example.md", "沙箱\n沙盤管理器\n沙箱管理器\n")
         self.commit()
         self.assertEqual(check(self.repo, self.base), [
             Violation(path, 2, "沙箱"), Violation(path, 3, "沙盘"),
         ])
+
+    def test_manager_names_receive_context_warning_without_duplicate_terms(self):
+        path = "docs/zh-CN/Content/Managers.md"
+        terms = ("沙盘管理器", "沙盒管理器", "沙箱管理器")
+        self.write(path, "\n".join(terms) + "\n")
+        self.commit()
+        findings = check(self.repo, self.base)
+        self.assertEqual(findings, [
+            Violation(path, line, term) for line, term in enumerate(terms, 1)
+        ])
+        for finding in findings:
+            with self.subTest(term=finding.term):
+                self.assertEqual(finding.severity, "warning")
+                self.assertTrue("SandMan" in finding.message)
+                self.assertTrue("Sandboxie Plus" in finding.message)
+                self.assertTrue("Sandboxie Control" in finding.message)
+                self.assertTrue("Classic" in finding.message)
+                self.assertTrue("Exact UI label quotations may be kept" in finding.message)
+
+    def test_manager_names_do_not_hide_standalone_deprecated_terms(self):
+        path = "docs/zh-CN/Content/Mixed.md"
+        self.write(path, "沙盘管理器、沙箱管理器、沙盘、沙箱\n")
+        self.commit()
+        findings = check(self.repo, self.base)
+        self.assertEqual(findings, [
+            Violation(path, 1, term) for term in ("沙盘", "沙盘管理器", "沙箱", "沙箱管理器")
+        ])
+        self.assertEqual([finding.severity for finding in findings], [
+            "error", "warning", "error", "warning",
+        ])
+
+    def test_canonical_manager_names_are_accepted(self):
+        self.write("docs/zh-CN/Content/Managers.md", "SandMan\nSandboxie Control\n沙盒\n")
+        self.commit()
+        self.assertEqual(check(self.repo, self.base), [])
 
     def test_both_readmes_are_checked(self):
         self.write("README_zh-CN.md", "沙箱\n")
@@ -83,20 +118,20 @@ class TermCheckTests(unittest.TestCase):
 
     def test_unchanged_legacy_line_is_ignored_but_edited_line_is_checked(self):
         path = "docs/zh-CN/Content/Example.md"
-        self.write(path, "沙箱。\n原有内容\n")
+        self.write(path, "沙箱。\n沙盒管理器\n原有内容\n")
         base = self.commit()
-        self.write(path, "沙箱。\n原有内容\n新增沙盒说明\n")
+        self.write(path, "沙箱。\n沙盒管理器\n原有内容\n新增沙盒说明\n")
         self.commit()
         self.assertEqual(check(self.repo, base), [])
-        self.write(path, "沙箱！\n原有内容\n新增沙盒说明\n")
+        self.write(path, "沙箱！\n沙盒管理器\n原有内容\n新增沙盒说明\n")
         self.commit()
         self.assertEqual(check(self.repo, base), [Violation(path, 1, "沙箱")])
 
     def test_deleted_file_and_removed_line_are_ignored(self):
         removed = "docs/zh-CN/Content/Removed.md"
         kept = "docs/zh-CN/Content/Kept.md"
-        self.write(removed, "沙箱\n")
-        self.write(kept, "沙盘\n保留内容\n")
+        self.write(removed, "沙箱\n沙箱管理器\n")
+        self.write(kept, "沙盘\n沙盒管理器\n保留内容\n")
         base = self.commit()
         (self.repo / removed).unlink()
         self.write(kept, "保留内容\n")
@@ -154,31 +189,56 @@ class TermCheckTests(unittest.TestCase):
         self.assertEqual(check(self.repo, self.base), [Violation(path, 1501, "沙箱")])
 
     def test_github_annotation_escapes_control_characters(self):
-        result = github_error(Violation("docs/zh-CN/a%,:\r\n::error.md", 7, "沙箱"))
+        result = github_annotation(Violation("docs/zh-CN/a%,:\r\n::error.md", 7, "沙箱"))
         self.assertEqual(result, "::error file=docs/zh-CN/a%25%2C%3A%0D%0A%3A%3Aerror.md,line=7::"
                          "Use '沙盒' instead of '沙箱' in Simplified Chinese documentation.")
+        warning = Violation("docs/zh-CN/a%,:\r\n::warning.md", 8, "沙盒管理器")
+        self.assertEqual(github_annotation(warning),
+                         "::warning file=docs/zh-CN/a%25%2C%3A%0D%0A%3A%3Awarning.md,line=8::"
+                         + warning.message)
 
     def test_cli_exit_status_and_annotations(self):
         script = self.repo / "tools" / "check_zh_terms.py"
         script.parent.mkdir()
         shutil.copyfile(Path(__file__).with_name("check_zh_terms.py"), script)
 
-        def run(base):
+        def run(base, annotations):
             return subprocess.run(
-                [sys.executable, str(script), "--base", base, "--github-actions"],
+                [sys.executable, str(script), "--base", base]
+                + (["--github-actions"] if annotations else []),
                 env={**self.env, "PYTHONIOENCODING": "utf-8"},
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8",
             )
 
-        self.assertEqual(run(self.base).returncode, 0)
-        self.write("docs/zh-CN/Content/Test.md", "沙盘\n")
-        self.commit()
-        result = run(self.base)
-        self.assertEqual(result.returncode, 1)
-        self.assertIn("::error file=docs/zh-CN/Content/Test.md,line=1::", result.stdout)  # codespell:ignore assertin
-        result = run("missing-revision")
-        self.assertEqual(result.returncode, 2)
-        self.assertIn("::error::Unable to check", result.stdout)  # codespell:ignore assertin
+        path = "docs/zh-CN/Content/Test.md"
+        cases = (
+            ("SandMan\n", 0, ()),
+            ("沙盒管理器\n", 0, (("warning", 1),)),
+            ("沙盘\n", 1, (("error", 1),)),
+            ("沙箱管理器\n沙箱\n", 1, (("warning", 1), ("error", 2))),
+        )
+        for content, status, findings in cases:
+            self.write(path, content)
+            self.commit()
+            for annotations in (False, True):
+                with self.subTest(content=content, annotations=annotations):
+                    result = run(self.base, annotations)
+                    self.assertEqual(result.returncode, status, result.stderr)
+                    for severity, line in findings:
+                        expected = (f"::{severity} file={path},line={line}::" if annotations
+                                    else f"{path}:{line}: {severity}:")
+                        self.assertTrue(expected in result.stdout, result.stdout)
+                    if not annotations:
+                        self.assertFalse("::warning" in result.stdout)
+                        self.assertFalse("::error" in result.stdout)
+        for annotations in (False, True):
+            with self.subTest(invalid_revision=True, annotations=annotations):
+                result = run("missing-revision", annotations)
+                self.assertEqual(result.returncode, 2)
+                if annotations:
+                    self.assertIn("::error::Unable to check", result.stdout)  # codespell:ignore assertin
+                else:
+                    self.assertTrue("Unable to check" in result.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/test_check_zh_terms.py
+++ b/tools/test_check_zh_terms.py
@@ -175,10 +175,10 @@ class TermCheckTests(unittest.TestCase):
         self.commit()
         result = run(self.base)
         self.assertEqual(result.returncode, 1)
-        self.assertIn("::error file=docs/zh-CN/Content/Test.md,line=1::", result.stdout)
+        self.assertIn("::error file=docs/zh-CN/Content/Test.md,line=1::", result.stdout)  # codespell:ignore assertin
         result = run("missing-revision")
         self.assertEqual(result.returncode, 2)
-        self.assertIn("::error::Unable to check", result.stdout)
+        self.assertIn("::error::Unable to check", result.stdout)  # codespell:ignore assertin
 
 
 if __name__ == "__main__":

--- a/tools/test_check_zh_terms.py
+++ b/tools/test_check_zh_terms.py
@@ -1,0 +1,185 @@
+"""Exercise the terminology check against real, isolated Git histories."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from check_zh_terms import Violation, check, github_error, is_target
+
+
+class TermCheckTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.repo = Path(self.temp.name)
+        self.env = os.environ.copy()
+        self.env.update(GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
+        for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"):
+            self.env.pop(name, None)
+        env_patch = patch.dict(os.environ, self.env, clear=True)
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
+        self.git("init", "-b", "main")
+        for key, value in {
+            "user.name": "Checker Test",
+            "user.email": "checker@example.invalid",
+            "commit.gpgsign": "false",
+            "core.hooksPath": str(self.repo / "no-hooks"),
+            "core.autocrlf": "false",
+        }.items():
+            self.git("config", key, value)
+        self.write("README.md", "Fixture\n")
+        self.base = self.commit()
+
+    def git(self, *args):
+        return subprocess.run(
+            ["git", "-C", str(self.repo), *args], env=self.env,
+            check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        ).stdout.decode("utf-8").strip()
+
+    def write(self, path, text):
+        target = self.repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8", newline="")
+
+    def commit(self):
+        self.git("add", "--all")
+        self.git("commit", "-m", "Fixture change")
+        return self.git("rev-parse", "HEAD")
+
+    def test_scope(self):
+        for path in ("docs/zh-CN/README.md", "docs/zh-CN/Content/Test.md", "README_zh-CN.md"):
+            with self.subTest(path=path):
+                self.assertTrue(is_target(path))
+        for path in ("README.md", "docs/Content/Test.md", "docs/zh-TW/Test.md",
+                     "docs/zh-CN/Test.png", "other/README_zh-CN.md"):
+            with self.subTest(path=path):
+                self.assertFalse(is_target(path))
+
+    def test_terms_and_literal_paths(self):
+        path = "docs/zh-CN/Content/中文 [one] file.md"
+        self.write(path, "沙盒、磁盘和工具箱\n沙箱中的沙箱\n沙盘中的沙盒\n")
+        self.write("docs/zh-CN/Content/中文 o file.md", "沙盒\n")
+        self.write("docs/Content/English.md", "沙箱\n")
+        self.write("docs/zh-TW/Example.md", "沙箱\n")
+        self.commit()
+        self.assertEqual(check(self.repo, self.base), [
+            Violation(path, 2, "沙箱"), Violation(path, 3, "沙盘"),
+        ])
+
+    def test_both_readmes_are_checked(self):
+        self.write("README_zh-CN.md", "沙箱\n")
+        self.write("docs/zh-CN/README.md", "沙盘\n")
+        self.commit()
+        self.assertEqual(check(self.repo, self.base), [
+            Violation("README_zh-CN.md", 1, "沙箱"),
+            Violation("docs/zh-CN/README.md", 1, "沙盘"),
+        ])
+
+    def test_unchanged_legacy_line_is_ignored_but_edited_line_is_checked(self):
+        path = "docs/zh-CN/Content/Example.md"
+        self.write(path, "沙箱。\n原有内容\n")
+        base = self.commit()
+        self.write(path, "沙箱。\n原有内容\n新增沙盒说明\n")
+        self.commit()
+        self.assertEqual(check(self.repo, base), [])
+        self.write(path, "沙箱！\n原有内容\n新增沙盒说明\n")
+        self.commit()
+        self.assertEqual(check(self.repo, base), [Violation(path, 1, "沙箱")])
+
+    def test_deleted_file_and_removed_line_are_ignored(self):
+        removed = "docs/zh-CN/Content/Removed.md"
+        kept = "docs/zh-CN/Content/Kept.md"
+        self.write(removed, "沙箱\n")
+        self.write(kept, "沙盘\n保留内容\n")
+        base = self.commit()
+        (self.repo / removed).unlink()
+        self.write(kept, "保留内容\n")
+        self.commit()
+        self.assertEqual(check(self.repo, base), [])
+
+    def test_multiple_hunks_plus_prefix_and_missing_final_newline(self):
+        path = "docs/zh-CN/Content/Hunks.md"
+        lines = [f"原有内容 {i}" for i in range(20)]
+        self.write(path, "\n".join(lines))
+        base = self.commit()
+        lines[1] = "+++沙箱"
+        lines[15] = "沙盒"
+        lines[19] = "沙盘"
+        self.write(path, "\n".join(lines))
+        self.commit()
+        self.assertEqual(check(self.repo, base), [
+            Violation(path, 2, "沙箱"), Violation(path, 20, "沙盘"),
+        ])
+
+    def test_diverged_base_uses_merge_base(self):
+        path = "docs/zh-CN/Content/Legacy.md"
+        self.write(path, "沙箱\n")
+        common = self.commit()
+        self.write(path, "沙盒\n")
+        base = self.commit()
+        self.git("checkout", "-b", "feature", common)
+        self.write("README.md", "Feature documentation\n")
+        head = self.commit()
+        self.assertEqual(check(self.repo, base, head), [])
+
+    def test_move_into_chinese_scope_is_checked(self):
+        source = "docs/Content/Move.md"
+        target = "docs/zh-CN/Content/Move.md"
+        self.write(source, "沙箱\n")
+        base = self.commit()
+        (self.repo / target).parent.mkdir(parents=True)
+        (self.repo / source).rename(self.repo / target)
+        self.commit()
+        self.assertEqual(check(self.repo, base), [Violation(target, 1, "沙箱")])
+
+    def test_invalid_and_option_like_revisions_fail(self):
+        for revision in ("nonexistent-revision", "--help", "--output=unexpected-file"):
+            with self.subTest(revision=revision):
+                with self.assertRaises(RuntimeError):
+                    check(self.repo, revision)
+                with self.assertRaises(RuntimeError):
+                    check(self.repo, self.base, revision)
+        self.assertFalse((self.repo / "unexpected-file").exists())
+
+    def test_large_diff_reaches_last_line(self):
+        path = "docs/zh-CN/Content/Large.md"
+        self.write(path, ("沙盒说明 " + "a" * 100 + "\n") * 1500 + "沙箱\n")
+        self.commit()
+        self.assertEqual(check(self.repo, self.base), [Violation(path, 1501, "沙箱")])
+
+    def test_github_annotation_escapes_control_characters(self):
+        result = github_error(Violation("docs/zh-CN/a%,:\r\n::error.md", 7, "沙箱"))
+        self.assertEqual(result, "::error file=docs/zh-CN/a%25%2C%3A%0D%0A%3A%3Aerror.md,line=7::"
+                         "Use '沙盒' instead of '沙箱' in Simplified Chinese documentation.")
+
+    def test_cli_exit_status_and_annotations(self):
+        script = self.repo / "tools" / "check_zh_terms.py"
+        script.parent.mkdir()
+        shutil.copyfile(Path(__file__).with_name("check_zh_terms.py"), script)
+
+        def run(base):
+            return subprocess.run(
+                [sys.executable, str(script), "--base", base, "--github-actions"],
+                env={**self.env, "PYTHONIOENCODING": "utf-8"},
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8",
+            )
+
+        self.assertEqual(run(self.base).returncode, 0)
+        self.write("docs/zh-CN/Content/Test.md", "沙盘\n")
+        self.commit()
+        result = run(self.base)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("::error file=docs/zh-CN/Content/Test.md,line=1::", result.stdout)
+        result = run("missing-revision")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("::error::Unable to check", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a PR check that rejects `沙箱` and `沙盘` in added lines of `docs/zh-CN/**/*.md` and `README_zh-CN.md`, following #250 and sandboxie-plus/Sandboxie#5547. It suggests `沙盒`. Unchanged lines are left alone; editing a line checks the whole new line.

`沙盘管理器`, `沙盒管理器` and `沙箱管理器` produce warnings only, since the right name depends on whether the text refers to `SandMan` (Plus) or `Sandboxie Control` (Classic). Exact UI label quotations can stay. A manager name does not also produce an error for the shorter term inside it.
